### PR TITLE
feat: allow invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dc-visualization-delivery-preview
 
 To use this visualization app it first needs to be added to a content type inside DC. It has a number of functions:
-  * **Realtime** - This displays the in-progress content, even if it hasn't yet been saved. **Note:** all required fields need to be filled and valid for this to update.
+  * **Realtime** - This displays the in-progress content, even if it hasn't yet been saved.
   * **Staged** - This displays the latest version of your saved content.
   * **Live** - This displays the published version of your content.
   * **Diff** - This tab displays the difference between the available tabs.
@@ -13,7 +13,7 @@ To use this visualization app it first needs to be added to a content type insid
   * `vse` - Your virtual staging environment, usually {{vse.domain}}. Required for staging tab.
   * `hub` - Your hub name, required for live tab.
   * `realtime` - Realtime flag, required for Realtime tab, should be true.
-  * `locale` - The locale to use, usually {{locales}}. Optional: if not used the realtime locale switching will be faster, but there will be no locale filtering for Staging and Live tabs.
+  * `locale` - The locale to use, usually {{locales}}. This is not needed when using a realtime connection.
   
 ### Options
   <p>The following options can be used to configure the default Delivery API request options:</p>
@@ -22,7 +22,7 @@ To use this visualization app it first needs to be added to a content type insid
   * `depth` - Can either be `root` or `all` (default).
   
   <h2>Example URL to use</h2>
-http://localhost:5000?id={{content.sys.id}}&vse={{vse.domain}}&locale={{locales}}&hub=your-hub&realtime=true
+http://localhost:3400?id={{content.sys.id}}&vse={{vse.domain}}&locale={{locales}}&hub=your-hub&realtime=true
 
 ## Get started
 
@@ -36,7 +36,7 @@ npm install
 npm run dev
 ```
 
-Navigate to [localhost:5000](http://localhost:5000). You should see your app running. 
+Navigate to [localhost:3400](http://localhost:3400). You should see your app running. 
 
 ## Building and running in production mode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2525,9 +2525,9 @@
       }
     },
     "dc-visualization-sdk": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dc-visualization-sdk/-/dc-visualization-sdk-1.0.2.tgz",
-      "integrity": "sha512-6jQon8JqQfMBdm8wErjLR3qa3it641qmZDIGlzTSJYbbrRZDIPSou0tosV5zMUBjnEfobFywz8VwaA7ZWgz8uQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dc-visualization-sdk/-/dc-visualization-sdk-1.1.0.tgz",
+      "integrity": "sha512-w3c/kWIAdphwUROoOh0/TzjWEpHi30IMW2XzgF59NAm+xQo7UMZvwYBf0eyiuFV4NfGdZOY3fMyJd82p+xT1yQ==",
       "requires": {
         "message-event-channel": "^1.1.0",
         "object-hash": "^2.1.1"
@@ -6080,9 +6080,9 @@
       }
     },
     "object-hash": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
-      "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-visualization-delivery-preview",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-visualization-delivery-preview",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public",
+    "start": "sirv public -p 3400",
     "lint": "prettier --check \"src/**/*.{js,svelte,html}\" && eslint \"src/**/*.{js,svelte}\"",
     "format": "prettier --write \"src/**/*.{js,svelte,html}\" && eslint --fix \"src/**/*.{js,svelte}\""
   },
@@ -27,7 +27,7 @@
     "rollup-plugin-terser": "^5.3.1"
   },
   "dependencies": {
-    "dc-visualization-sdk": "^1.0.2",
+    "dc-visualization-sdk": "^1.1.0",
     "diff": "^5.0.0",
     "sirv-cli": "^0.4.4",
     "svelte": "^3.38.2",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,8 +67,4 @@
   .realtime {
     grid-area: realtime;
   }
-
-  .grey {
-    color: #777;
-  }
 </style>

--- a/src/Help.svelte
+++ b/src/Help.svelte
@@ -11,9 +11,8 @@
   </p>
   <ul>
     <li>
-      <b>Realtime</b> - This will show the in-progress content, even if it
-      hasn't yet been saved. <b>Note:</b> all required fields need to be filled and
-      valid for this to show.
+      <b>Realtime</b> - This will show the in-progress content, even if it hasn't
+      yet been saved.
     </li>
     <li>
       <b>Staged</b> - This shows the latest version of your saved content.
@@ -41,8 +40,7 @@
     </li>
     <li>
       <code>locale</code> - The locale to use, usually &lbrace;&lbrace;locales&rbrace;&rbrace;.
-      Optional: if not used the realtime locale switching will be faster, but there
-      will be no locale filtering for Staging and Live tabs.
+      This is not needed when using a realtime connection.
     </li>
   </ul>
   <h2>Options</h2>
@@ -73,6 +71,7 @@
 <style>
   main {
     padding: 0 2rem;
+    overflow-y: auto;
   }
   button {
     display: inline-block;

--- a/src/data/data.service.js
+++ b/src/data/data.service.js
@@ -2,7 +2,7 @@ import { writable, get } from 'svelte/store';
 import { cdService } from './cd.service.js';
 import { visService, connected } from './vis.service.js';
 import { selected } from '../menu/menu.store';
-import { depth, hub, format } from '../settings/settings.store';
+import { depth, hub, format, locale } from '../settings/settings.store';
 export let mainContent = writable();
 export let secondaryContent = writable();
 export let base = writable('live');
@@ -134,6 +134,7 @@ const update = async () => {
 };
 
 selected.subscribe(update);
+locale.subscribe(update);
 depth.subscribe(update);
 hub.subscribe(update);
 format.subscribe(update);

--- a/src/data/vis.service.js
+++ b/src/data/vis.service.js
@@ -17,15 +17,17 @@ class VisService {
       content = await this.sdk.form.get({
         format: get(format),
         depth: get(depth),
+        allowInvalid: true,
       });
       this.lastSuccess = content;
     } catch (e) {
       content = this.lastSuccess || {};
       toast.push(e.errors[0].message, {
-        duration: 2500, theme: {
+        duration: 2500,
+        theme: {
           '--toastBackground': '#F56565',
-          '--toastProgressBackground': '#C53030'
-        }
+          '--toastProgressBackground': '#C53030',
+        },
       });
     }
     return content;
@@ -77,6 +79,7 @@ class VisService {
       {
         format: get(format),
         depth: get(depth),
+        allowInvalid: true,
       }
     );
   }

--- a/src/json-viewers/JsonViewer.svelte
+++ b/src/json-viewers/JsonViewer.svelte
@@ -9,7 +9,7 @@
 {#if content}
   <pre>
   <code class="json">
-    {@html hljs.highlight('json', JSON.stringify(content, null, 2), true).value}
+    {@html hljs.highlight(JSON.stringify(content, null, 2), {language: 'json', ignoreIllegals: true}).value}
   </code>
 </pre>
 {/if}

--- a/src/realtime/Realtime.svelte
+++ b/src/realtime/Realtime.svelte
@@ -24,7 +24,7 @@
     if (!c) {
       return;
     }
-    visService.sdk.form.changed(() => flash(editIcon));
+    visService.sdk.form.changed(() => flash(editIcon), { allowInvalid: true });
     visService.sdk.form.saved(() => flash(saveIcon));
     settings = await visService.sdk.settings.get();
     locale.set(await visService.sdk.locale.get());


### PR DESCRIPTION
- added `allowInvalid: true` param to allow  the realtime view to always show the latest in-progress JSON
- updated hljs param ordering as current ordering is being deprecated and to suppress warnings in console
- fixed an issue where updating locale would not update live or staged data correctly if `{{locales}}` url param wasn't present
- updated help and readme